### PR TITLE
feat: Add get-font-info command to parse .fnt files

### DIFF
--- a/src/commands/get-font-info.js
+++ b/src/commands/get-font-info.js
@@ -1,0 +1,48 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import chalk from 'chalk';
+
+/**
+ * @param {string} target
+ */
+export async function getFontInfo(target = '.') {
+    const baseDir = path.resolve(process.cwd(), target);
+    try {
+        const files = await fs.readdir(baseDir);
+        const fntFiles = files.filter((file) => file.endsWith('.fnt'));
+
+        if (fntFiles.length === 0) {
+            console.log(chalk.yellow('No .fnt files found in the specified directory.'));
+            return;
+        }
+
+        for (const file of fntFiles) {
+            const filePath = path.join(baseDir, file);
+            const content = await fs.readFile(filePath, 'utf-8');
+            const lines = content.split('\n');
+            const infoLine = lines.find((line) => line.startsWith('info face='));
+
+            if (infoLine) {
+                const faceMatch = infoLine.match(/face="([^"]+)"/);
+                const sizeMatch = infoLine.match(/size=(-?\d+)/);
+
+                const fontName = faceMatch ? faceMatch[1] : 'N/A';
+                const fontSize = sizeMatch ? sizeMatch[1] : 'N/A';
+
+                console.log(`${chalk.cyan(file)}:`);
+                console.log(`  Font Name: ${chalk.green(fontName)}`);
+                console.log(`  Font Size: ${chalk.green(fontSize)}`);
+            } else {
+                console.log(`${chalk.cyan(file)}:`);
+                console.log(chalk.red('  "info" line not found.'));
+            }
+        }
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            console.error(chalk.red(`Error: The directory "${baseDir}" does not exist.`));
+        } else {
+            console.error(chalk.red(`An error occurred: ${error.message}`));
+        }
+        process.exitCode = 1;
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { createMod } from './commands/create-mod.js';
 import { runLint } from './commands/lint.js';
 import { showEquation } from './commands/showEquation.js';
+import { getFontInfo } from './commands/get-font-info.js';
 
 const DEFAULT_MOD_DIR =
   process.platform === 'win32'
@@ -38,5 +39,11 @@ program
     .argument('<file>', '対象ファイル')
     .argument('<variable>', '対象の変数名')
     .action(showEquation);
+
+program
+    .command('get-font-info')
+    .description('フォントファイル (.fnt) からフォント名とサイズを抽出')
+    .argument('[path]', '対象フォルダ', '.')
+    .action(getFontInfo);
 
 program.parse();


### PR DESCRIPTION
This change adds a new command 'get-font-info' that parses .fnt files in a specified directory and extracts the font name and size from the 'info' line. This is useful for quickly identifying the fonts used in the game.