### PR TITLE
feat: GFX/アイコン存在確認機能を追加

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,5 +73,11 @@ gfxCommand
     .argument('[path]', '対象フォルダ', '.')
     .action((path) => runGfx('convert', path));
 
+gfxCommand
+    .command('check-missing')
+    .description('GFX定義ファイルで参照されている存在しない画像をリストアップ')
+    .argument('[path]', '対象フォルダ', '.')
+    .action((path) => runGfx('check-missing', path));
+
 
 program.parse();


### PR DESCRIPTION
GFXファイルで参照されているテクスチャファイルが存在するかどうかを確認する機能を追加します。

- `gfx` コマンドに `check-missing` サブコマンドを追加。
- このコマンドは、`.gfx` ファイル内の `texturefile` で指定されたファイルをスキャンします。
- 参照されているファイルが存在しない場合、それらをリストアップして報告します。
- ファイルパスに拡張子がない場合でも、`.dds`、`.tga`、`.png` の各拡張子を試してチェックします。